### PR TITLE
Make the Chrome extension compatible with Firefox using WebExtensions API

### DIFF
--- a/app/html/options.html
+++ b/app/html/options.html
@@ -43,7 +43,7 @@
       <span class="sr-only">Close</span>
     </button>
     <div class="content">
-      <strong><i class="fa fa-info-circle"></i> Heads up!</strong> In order to use this extension on local files (i.e. files on this computer), you must check the option <code>Allow access to file URLs</code> on the <a id="openExtensionsPageLink" href="#">chrome://extensions</a> page
+      <strong><i class="fa fa-info-circle"></i> Heads up!</strong> If your are using Chrome, in order to use this extension on local files (i.e. files on this computer), you must check the option <code>Allow access to file URLs</code> on the <a id="openExtensionsPageLink" href="#">chrome://extensions</a> page
     </div>
   </div>
   <form class="form-horizontal" role="form">

--- a/app/js/asciidocify.js
+++ b/app/js/asciidocify.js
@@ -25,6 +25,11 @@ asciidoctor.chrome.asciidocify = function () {
 
 function loadContent() {
   $.ajax({
+    beforeSend: function (xhr) {
+      if (xhr.overrideMimeType) {
+        xhr.overrideMimeType("text/plain;charset=utf-8");
+      }
+    },
     url: location.href,
     cache: false,
     complete: function (data) {
@@ -86,6 +91,11 @@ function startAutoReload() {
   clearInterval(autoReloadInterval);
   autoReloadInterval = setInterval(function () {
     $.ajax({
+      beforeSend: function (xhr) {
+        if (xhr.overrideMimeType) {
+          xhr.overrideMimeType("text/plain;charset=utf-8");
+        }
+      },
       url: location.href,
       cache: false,
       success: function (data) {

--- a/app/js/renderer.js
+++ b/app/js/renderer.js
@@ -311,7 +311,7 @@ function removeCustomJs() {
 function refreshMathJax() {
   const mathJaxJsScript = document.createElement('script');
   mathJaxJsScript.id = 'mathjax-refresh-js';
-  mathJaxJsScript.text = 'if (window.MathJax) { window.MathJax.Hub.Typeset(); }';
+  mathJaxJsScript.text = 'if (window.MathJax && window.MathJax.Hub) { window.MathJax.Hub.Typeset(); }';
   document.body.appendChild(mathJaxJsScript);
 }
 

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -3,13 +3,6 @@
   "version":"1.5.5.101",
   "manifest_version":2,
 
-  "applications":{
-    "gecko":{
-      "id": "asciidoctor-preview-addon@asciidoctor",
-      "strict_min_version": "42.0"
-    }
-  },
-
   "description":"Render AsciiDoc (.ad, .adoc, .asc, .asciidoc) as HTML inside your browser!",
 
   "options_page":"html/options.html",

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -3,7 +3,14 @@
   "version":"1.5.5.101",
   "manifest_version":2,
 
-  "description":"Render AsciiDoc (.ad, .adoc, .asc, .asciidoc) as HTML inside Chrome!",
+  "applications":{
+    "gecko":{
+      "id": "asciidoctor-preview-addon@asciidoctor",
+      "strict_min_version": "42.0"
+    }
+  },
+
+  "description":"Render AsciiDoc (.ad, .adoc, .asc, .asciidoc) as HTML inside your browser!",
 
   "options_page":"html/options.html",
 
@@ -84,6 +91,14 @@
     "css/chartist.min.css",
     "img/themes/riak/*.png",
     "js/vendor/highlight.min.js",
+    "js/vendor/asciidoctor-chart-block-macro.js",
+    "js/vendor/asciidoctor-emoji-inline-macro.js",
+    "js/vendor/jquery.min.js",
+    "js/vendor/asciidoctor.js",
+    "js/vendor/md5.js",
+    "js/asciidocify.js",
+    "js/renderer.js",
+    "js/vendor/chartist.min.js",
     "js/vendor/asciidoctor-chart-block-macro.js",
     "js/vendor/asciidoctor-emoji-inline-macro.js",
     "fonts/fontawesome-webfont.woff2",


### PR DESCRIPTION
Tested in Firefox 54

**Known issues**
* `include` macro is not working with local path without protocol.
  * `include::/path/to/file.adoc[]` does not work
  * `include::file.adoc[]` does not work
  * `include::file:///path/to/file.adoc[]` does work!


