### PR TITLE
resolves #149 use correct config for MathJax

### DIFF
--- a/app/vendor/MathJax/config.js
+++ b/app/vendor/MathJax/config.js
@@ -1,6 +1,7 @@
 var MathJax = {
+  messageStyle: 'none',
   tex2jax: {
-    inlineMath: [['\\$','\\$'],['\\(','\\)']],
+    inlineMath: [['\\(','\\)']],
     displayMath: [['\\[', '\\]']],
     ignoreClass: 'nostem|nolatexmath'
   },


### PR DESCRIPTION
- prevents AsciiMath expressions from being parsed as tex
- add missing message config